### PR TITLE
Fix buffer restart integer overflow

### DIFF
--- a/modular/tech.py
+++ b/modular/tech.py
@@ -22,6 +22,10 @@ from datetime import datetime
 from contextlib import suppress
 import os
 
+GetTickCount64 = ctypes.windll.kernel32.GetTickCount64
+GetTickCount64.restype = ctypes.c_ulonglong
+
+
 class LASTINPUTINFO(ctypes.Structure):
     _fields_ = [("cbSize", wintypes.UINT),
                 ("dwTime", wintypes.DWORD)]
@@ -82,7 +86,7 @@ def get_time_since_last_input() -> int:
     last_input_info.cbSize = ctypes.sizeof(LASTINPUTINFO)
 
     if ctypes.windll.user32.GetLastInputInfo(ctypes.byref(last_input_info)):
-        current_time = ctypes.windll.kernel32.GetTickCount()
+        current_time = GetTickCount64()
         idle_time_ms = current_time - last_input_info.dwTime
         return idle_time_ms // 1000
     return 0

--- a/smart_replays.py
+++ b/smart_replays.py
@@ -1077,6 +1077,10 @@ def export_aliases_to_json_callback(*args):
 
 
 # -------------------- tech.py --------------------
+GetTickCount64 = ctypes.windll.kernel32.GetTickCount64
+GetTickCount64.restype = ctypes.c_ulonglong
+
+
 class LASTINPUTINFO(ctypes.Structure):
     _fields_ = [("cbSize", wintypes.UINT),
                 ("dwTime", wintypes.DWORD)]
@@ -1137,7 +1141,7 @@ def get_time_since_last_input() -> int:
     last_input_info.cbSize = ctypes.sizeof(LASTINPUTINFO)
 
     if ctypes.windll.user32.GetLastInputInfo(ctypes.byref(last_input_info)):
-        current_time = ctypes.windll.kernel32.GetTickCount()
+        current_time = GetTickCount64()
         idle_time_ms = current_time - last_input_info.dwTime
         return idle_time_ms // 1000
     return 0


### PR DESCRIPTION
I ran into the same problem described in #16 which seems to have been caused by `ctypes.windll.kernel32.GetTickCount` returning a 32 bit integer which can easily overflow since Windows Fast Startup doesn't reset uptime. Fixed by using `ctypes.windll.kernel32.GetTickCount64` instead. Now you can leave your PC on for ~500 billion years.

Fixes #16