### PR TITLE
fix: Prevent returning negative values in get_time_since_last_input()

### DIFF
--- a/smart_replays.py
+++ b/smart_replays.py
@@ -1143,7 +1143,7 @@ def get_time_since_last_input() -> int:
     if ctypes.windll.user32.GetLastInputInfo(ctypes.byref(last_input_info)):
         current_time = GetTickCount64()
         idle_time_ms = current_time - last_input_info.dwTime
-        return idle_time_ms // 1000
+        return max(idle_time_ms // 1000, 0)
     return 0
 
 


### PR DESCRIPTION
Hi,

I've recently started running into an issue where the calculation in get_time_since_last_input() seems to underflow(?):
```
[smart_replays.py] [10.10.2025 17:24:47] Replay length (60s) is greater then time since last input (-4294921s). Next call in 4294981.0s.
[smart_replays.py] OverflowError: Python int too large to convert to C long
[smart_replays.py]
[smart_replays.py] The above exception was the direct cause of the following exception:
[smart_replays.py]
[smart_replays.py] Traceback (most recent call last):
[smart_replays.py] File "C:\Program Files/obs-studio/data/obs-plugins/frontend-tools/scripts\smart_replays.py", line 1599, in restart_replay_buffering_callback
[smart_replays.py] obs.timer_add(restart_replay_buffering_callback, next_call)
[smart_replays.py] SystemError: <built-in function timer_add> returned a result with an exception set
```
Clamping the return value to a min value of 0 should fix this, assuming the function is supposed to return >=0.
Either way, just figured I'd report the bug. Thanks!
